### PR TITLE
Add a context menu with discover.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Folding code blocks based on indentation.
     map))
 ```
 
+### Discover commands with a context menu
+
+Call `M-x yafolding-discover` to have a magit-like context menu that
+displays the available commands. This feature relies on
+[discover.el](https://www.github.com/mickeynp/discover.el).
+
+To give it a keybinding:
+
+    (global-set-key (kbd "s-d y") 'yafolding-discover)
+
 ### Hook into prog-mode-hook
 
 ```emacs-lisp

--- a/yafolding.el
+++ b/yafolding.el
@@ -199,6 +199,28 @@
     (yafolding-go-parent-element)
     (yafolding-hide-element)))
 
+;; For this feature, you need to install discover.el
+;; https://www.github.com/mickeynp/discover.el
+(discover-add-context-menu
+ :context-menu '(yafolding
+              (description "folding based on indentation")
+              (actions
+               ("yafolding"
+                ("h" "hide element" yafolding-hide-element)
+                ("s" "show element" yafolding-show-element)
+                ("t" "toggle element" yafolding-toggle-element)
+                ("H" "hide all" yafolding-hide-all)
+                ("S" "show all" yafolding-show-all)
+                ("T" "toggle all" yafolding-toggle-all)
+                ("p" "go parent element" yafolding-go-parent-element)
+                ("P" "hide parent element" yafolding-hide-parent-element)
+                ("m" "mode" yafolding-mode)
+                )
+))
+)
+
+(defalias 'yafolding-discover 'makey-key-mode-popup-yafolding)
+
 ;;;###autoload
 (defvar yafolding-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
Here it is !
I added a simple listing of the commands.
Note that I didn't specify a default keybinding (I just said how to do it in the readme).
So this feature requires discover.el. Will you add it as a dependency of yafolding or say in the readme to install it ? I think it's easier to add it as a dependency and that doesn't have any drawbacks.
  I tested it with evaluating the whole buffer and calling M-x yafolding-discover.
  Tell me what you think !
