### PR TITLE
Suppress byte-compile warning

### DIFF
--- a/yafolding.el
+++ b/yafolding.el
@@ -27,6 +27,8 @@
 
 ;;; Code:
 
+(declare-function discover-add-context-menu "discover")
+
 (defgroup yafolding nil
   "Fold code blocks based on indentation level"
   :prefix "yafolding-"


### PR DESCRIPTION
This suppresses following a byte-compile warning.

```
yafolding.el:244:1:Warning: the function ‘discover-add-context-menu’ is not
    known to be defined.
```